### PR TITLE
Enable extra column in DataTable component

### DIFF
--- a/src/components/charts/DataTable.vue
+++ b/src/components/charts/DataTable.vue
@@ -3,30 +3,31 @@
     <table class="table table-sm table-bordered" v-if="data">
       <thead>
         <tr>
-          <th :colspan="Object.keys(tussenkopjes).length > 1 ? 2 : undefined"></th>
+          <th :colspan="Object.keys(data).length && Object.keys(data)[0] ? 2 : undefined"></th>
           <th v-for="y in years" :key="y" class="text-center">{{y}}</th>
         </tr>
       </thead>
-      <tbody>
-        <tr v-for="d in data" :key="d.variabele">
-          <td
-            :rowspan="tussenkopjes[d.meta.tussenkopje_kerncijfertabel]"
-            v-if="tussenkopjes[d.meta.tussenkopje_kerncijfertabel] > 1"
+
+      <tbody v-for="(d, tussenkopje) of data" :key="tussenkopje">
+        <tr v-for="item of d" :key="item.meta.variabele">
+          <th
+            scope="row"
+            :rowspan="d.length"
+            v-if="item.meta.tussenkopje_kerncijfertabel"
             valign="top"
           >
-            {{d.meta.tussenkopje_kerncijfertabel}}
-          </td>
+            {{item.meta.tussenkopje_kerncijfertabel}}
+          </th>
           <td>
-            <tooltip :cijfers="data" :cijfer="d">{{d.label}}</tooltip>
+            <tooltip :cijfers="d" :cijfer="item">{{item.label}}</tooltip>
           </td>
           <td
             v-for="y in years" :key="y"
-            :style="{'background-color': d[y].color, 'color' : d[y].textColor}"
-            v-if="d[y]"
+            :style="{'background-color': item[y].color, 'color' : item[y].textColor}"
             class="text-center"
           >
-            <tooltip :cijfers="data" :cijfer="d" v-if="d[y].waarde">{{ d[y] | displaywaarde }}</tooltip>
-            <tooltip :cijfers="data" :cijfer="d" v-else>n.b.</tooltip>
+            <tooltip :cijfers="d" :cijfer="item" v-if="item[y].waarde">{{ item[y] | displaywaarde }}</tooltip>
+            <tooltip :cijfers="d" :cijfer="item" v-else>n.b.</tooltip>
           </td>
         </tr>
       </tbody>
@@ -64,6 +65,36 @@ export default {
     async updateData () {
       const data = await util.getConfigCijfers(this.gwb, this.config)
 
+      // temp var for demo purposes; will be removed after client approval
+      const tussenkopjes = [
+        'Brandveiligheid',
+        'Cultuur',
+        'Diversiteit',
+        'Duurzaamheid',
+        'Huishoudens',
+        'Inkomen',
+        'Jeugd',
+        'Onderwijs',
+        'Oordeel buurt',
+        'Openbare ruimte',
+        'Overlast',
+        'Participatie',
+        'Personen',
+        'Sport',
+        'Veiligheid',
+        'Verkeer',
+        'Vestigingen',
+        'Welzijn',
+        'Werk',
+        'Werkgelegenheid',
+        'Wonen',
+        'Woningprijzen',
+        'Woningvoorraad',
+        'Zorg'
+      ]
+      // temp var for demo purposes; will be removed after client approval
+      const tussenKopjesSlice = tussenkopjes.sort(() => 0.5 - Math.random()).slice(0, Math.floor((Math.random() * 4 + 1)))
+
       /**
        * Show the last 4 years only
        * @type {*}
@@ -71,47 +102,38 @@ export default {
       const cijfers = util.getYearCijfers(data)
       const maxYear = util.getMaxYear(cijfers)
       this.years = [3, 2, 1, 0].map(i => maxYear - i)
-      this.tussenkopjes = {};
+      const categorizedData = {}
 
       for (let item of data) {
+        // temp var for demo purposes; will be removed after client approval
+        const randomTussenkopje = tussenKopjesSlice[Math.floor(Math.random() * tussenKopjesSlice.length)]
+        // temp var for demo purposes; will be removed after client approval
+        const index = tussenKopjesSlice.indexOf(randomTussenkopje)
+
+        // temp var for demo purposes; will be removed after client approval
+        item.meta.tussenkopje_kerncijfertabel = randomTussenkopje
+        // temp var for demo purposes; will be removed after client approval
+        item.meta.volgorde_kerncijfertabel = index
         item.tooltipText = item.tooltip ? item.tooltip(false) : ''
 
-        if (!Object.keys(this.tussenkopjes).includes(item.meta.tussenkopje_kerncijfertabel)) {
-          this.tussenkopjes[item.meta.tussenkopje_kerncijfertabel] = 0;
+        if (!Object.keys(categorizedData).includes(randomTussenkopje)) {
+          categorizedData[randomTussenkopje] = []
+        } else {
+          item.meta.tussenkopje_kerncijfertabel = undefined
         }
 
-        this.tussenkopjes[item.meta.tussenkopje_kerncijfertabel] += 1;
+        categorizedData[randomTussenkopje].push(item)
 
         for (let year of this.years) {
-          item[year] = {jaar: year, waarde: ''}
+          item[year] = { jaar: year, waarde: '' }
+
           if (item.cijfers) {
             item[year] = item.cijfers.find(c => c.jaar === year) || item[year]
           }
         }
       }
 
-      /**
-       * Sorting data items on value of tussenkopje_kerncijfertabel prop in item meta
-       */
-      if (data.some(({ meta }) => meta.tussenkopje_kerncijfertabel)) {
-        let tussenkopje;
-
-        data
-          .sort((a, b) => a.meta.tussenkopje_kerncijfertabel.localeCompare(b.meta.tussenkopje_kerncijfertabel))
-          .map((item) => {
-            const { tussenkopje_kerncijfertabel } = item.meta;
-
-            if (tussenkopje && tussenkopje === tussenkopje_kerncijfertabel) {
-              item.meta.tussenkopje_kerncijfertabel = undefined;
-            } else {
-              tussenkopje = tussenkopje_kerncijfertabel
-            }
-
-            return item
-          })
-      }
-
-      this.data = data
+      this.data = categorizedData
     }
   },
   watch: {
@@ -128,6 +150,18 @@ export default {
 <style scoped>
   td.text-center {
     text-align: center;
+  }
+
+  table tbody {
+    border-bottom: 1px solid #bebebe;
+  }
+
+  table tbody th {
+    font-family: "AvenirNextLTW01-Regular", verdana, sans-serif;
+  }
+
+  table tbody tr:first-child td {
+    border-top: 1px solid black;
   }
 
   table tr:hover {

--- a/src/components/dashboards/OnderwijsJeugdEnDiversiteit.vue
+++ b/src/components/dashboards/OnderwijsJeugdEnDiversiteit.vue
@@ -4,7 +4,7 @@
         <div class="col-12 card">
           <div class="row">
             <div class="col-12 grid-title">
-              <h2>Bewoners over veiligheid en overlast in hun eigen buurt</h2>
+              <h2>Bewoners over {{ONDERWIJS_JEUGD_EN_DIVERSITEIT}}</h2>
             </div>
           </div>
           <div class="row">
@@ -78,7 +78,8 @@ export default {
     return {
       onderwijsJeugd,
       diversiteit,
-      kerncijfers
+      kerncijfers,
+      ONDERWIJS_JEUGD_EN_DIVERSITEIT
     }
   },
   computed: {

--- a/src/services/apis/bbga.js
+++ b/src/services/apis/bbga.js
@@ -27,7 +27,7 @@ export async function getAllMeta () {
     const data = await readPaginatedData(url)
     const dataObject = {}
 
-    data.forEach((item) => {
+    data.forEach(item => {
       dataObject[item.variabele.toUpperCase()] = item
     })
 

--- a/src/services/apis/bbga.js
+++ b/src/services/apis/bbga.js
@@ -26,7 +26,11 @@ export async function getAllMeta () {
     const url = getUrl('/meta/')
     const data = await readPaginatedData(url)
     const dataObject = {}
-    data.forEach(item => { dataObject[item.variabele.toUpperCase()] = item })
+
+    data.forEach((item) => {
+      dataObject[item.variabele.toUpperCase()] = item
+    })
+
     return dataObject
   }
 


### PR DESCRIPTION
This PR changes the `DataTable` component so that:
- items are sorted by the value of the column `tussenkopje_kerncijfertabel` in an item's `meta` property
- renders an extra `<td>` in the `DataTable`'s `<tbody>` element and gives the corresponding `<th>` element a rowspan of '2'