### PR TITLE
(Chore) Hide theme

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -1,5 +1,6 @@
 module.exports = {
   presets: [
+    '@babel/env',
     '@vue/app'
   ]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -6486,7 +6486,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -6507,12 +6508,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -6527,17 +6530,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -6654,7 +6660,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -6666,6 +6673,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -6680,6 +6688,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -6687,12 +6696,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -6711,6 +6722,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -6791,7 +6803,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -6803,6 +6816,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -6888,7 +6902,8 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -6924,6 +6939,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -6943,6 +6959,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -6986,12 +7003,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -13016,7 +13035,8 @@
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/rx-lite/-/rx-lite-4.0.8.tgz",
       "integrity": "sha1-Cx4Rr4vESDbwSmQH6S2kJGe3lEQ=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "rx-lite-aggregates": {
       "version": "4.0.8",

--- a/src/components/layout/Dashboard.vue
+++ b/src/components/layout/Dashboard.vue
@@ -20,7 +20,6 @@
       <verkeer-en-openbare-ruimte v-if="thema === VERKEER_EN_OPENBARE_RUIMTE"></verkeer-en-openbare-ruimte>
       <welzijn-zorg-en-sport v-if="thema === WELZIJN_ZORG_EN_SPORT"></welzijn-zorg-en-sport>
       <werk-inkomen-en-participatie v-if="thema === WERK_INKOMEN_EN_PARTICIPATIE"></werk-inkomen-en-participatie>
-      <sociale-kracht v-if="thema === SOCIALE_KRACHT"></sociale-kracht>
     </div>
     </div>
 </template>
@@ -37,8 +36,7 @@ import {
   STEDELIJKE_ONTWIKKELING_EN_WONEN,
   VERKEER_EN_OPENBARE_RUIMTE,
   WELZIJN_ZORG_EN_SPORT,
-  WERK_INKOMEN_EN_PARTICIPATIE,
-  SOCIALE_KRACHT
+  WERK_INKOMEN_EN_PARTICIPATIE
 } from '../../services/thema'
 
 import gwbMap from '../GWBMap'
@@ -54,7 +52,6 @@ import stedelijkeOntwikkelingEnWonen from '../dashboards/StedelijkeOntwikkelingE
 import verkeerEnOpenbareRuimte from '../dashboards/VerkeerEnOpenbareRuimte'
 import welzijnZorgEnSport from '../dashboards/WelzijnZorgEnSport'
 import werkInkomenEnParticipatie from '../dashboards/WerkInkomenEnParticipatie'
-import socialeKracht from '../dashboards/SocialeKracht'
 
 export default {
   name: 'GGWDashboard',
@@ -70,8 +67,7 @@ export default {
     'stedelijke-ontwikkeling-en-wonen': stedelijkeOntwikkelingEnWonen,
     'verkeer-en-openbare-ruimte': verkeerEnOpenbareRuimte,
     'welzijn-zorg-en-sport': welzijnZorgEnSport,
-    'werk-inkomen-en-participatie': werkInkomenEnParticipatie,
-    'sociale-kracht': socialeKracht
+    'werk-inkomen-en-participatie': werkInkomenEnParticipatie
   },
   data () {
     return {
@@ -84,8 +80,7 @@ export default {
       STEDELIJKE_ONTWIKKELING_EN_WONEN,
       VERKEER_EN_OPENBARE_RUIMTE,
       WELZIJN_ZORG_EN_SPORT,
-      WERK_INKOMEN_EN_PARTICIPATIE,
-      SOCIALE_KRACHT
+      WERK_INKOMEN_EN_PARTICIPATIE
     }
   },
   computed: {

--- a/src/services/thema.js
+++ b/src/services/thema.js
@@ -17,7 +17,6 @@ export const STEDELIJKE_ONTWIKKELING_EN_WONEN = 'Stedelijke ontwikkeling en wone
 export const VERKEER_EN_OPENBARE_RUIMTE = 'Verkeer en Openbare ruimte'
 export const WELZIJN_ZORG_EN_SPORT = 'Welzijn, zorg en sport'
 export const WERK_INKOMEN_EN_PARTICIPATIE = 'Werk, inkomen en participatie'
-export const SOCIALE_KRACHT = 'Sociale kracht'
 
 /**
  * The total set of available themas of which the user can choose from
@@ -33,8 +32,7 @@ export const THEMAS = [
   OPENBARE_ORDE_EN_VEILIGHEID,
   ONDERWIJS_JEUGD_EN_DIVERSITEIT,
   WERK_INKOMEN_EN_PARTICIPATIE,
-  WELZIJN_ZORG_EN_SPORT,
-  SOCIALE_KRACHT
+  WELZIJN_ZORG_EN_SPORT
 ]
 
 /**


### PR DESCRIPTION
This PR removes all necessary references to the new theme. This needs to be done, because a release is planned, but the new theme shouldn't be visible yet, since the API doesn't have the data that is required to make the theme present the correct figures.

Another minor change is the inclusion of `@babel/env` preset for file transpilation when running tests.