### PR TITLE
(Chore) Hide context menu

### DIFF
--- a/src/components/charts/HorizontalBarChart.vue
+++ b/src/components/charts/HorizontalBarChart.vue
@@ -22,11 +22,7 @@ import vegaSpec from '../../../static/charts/horizontalbar'
 import { COLOR } from '../../services/colorcoding'
 
 const vegaEmbedOptions = {
-  'actions': {
-    'export': false,
-    'source': false,
-    'editor': false
-  },
+  'actions': false,
   'renderer': 'svg'
 }
 

--- a/src/components/charts/LineChart.vue
+++ b/src/components/charts/LineChart.vue
@@ -15,11 +15,7 @@ import vegaSpec from '../../../static/charts/linechart5'
 import { LINE_CHART_COLORS } from '../../services/colorcoding'
 
 const vegaEmbedOptions = {
-  'actions': {
-    'export': false,
-    'source': false,
-    'editor': false
-  },
+  'actions': false,
   'renderer': 'svg'
 }
 

--- a/src/components/charts/PieChart.vue
+++ b/src/components/charts/PieChart.vue
@@ -22,11 +22,7 @@ import vegaSpec from '../../../static/charts/pie'
 import { PIE_CHART_COLORS } from '../../services/colorcoding'
 
 const vegaEmbedOptions = {
-  'actions': {
-    'export': false,
-    'source': false,
-    'editor': false
-  },
+  'actions': false,
   'renderer': 'svg'
 }
 

--- a/src/components/charts/StackedBarChart.vue
+++ b/src/components/charts/StackedBarChart.vue
@@ -15,11 +15,7 @@ import vegaSpec from '../../../static/charts/stackedbar5'
 import { STACKED_CHART_COLORS } from '../../services/colorcoding'
 
 const vegaEmbedOptions = {
-  'actions': {
-    'export': false,
-    'source': false,
-    'editor': false
-  },
+  'actions': false,
   'renderer': 'svg'
 }
 

--- a/src/components/charts/VerticalBarChart.vue
+++ b/src/components/charts/VerticalBarChart.vue
@@ -21,11 +21,7 @@ import vegaSpec from '../../../static/charts/verticalbar'
 import { COLOR } from '../../services/colorcoding'
 
 const vegaEmbedOptions = {
-  'actions': {
-    'export': false,
-    'source': false,
-    'editor': false
-  },
+  'actions': false,
   'renderer': 'svg'
 }
 


### PR DESCRIPTION
This PR hides the context menu button from graphs.

The context menu doesn't have any content, so it doesn't make sense to show it (see screenshot).
<img width="524" alt="Screenshot 2019-03-25 at 16 40 36" src="https://user-images.githubusercontent.com/1062191/54933365-d0aa2180-4f1c-11e9-83f9-c6fa12668bda.png">
