### PR TITLE
(Fix) Chart container height

### DIFF
--- a/src/components/charts/PieChart.vue
+++ b/src/components/charts/PieChart.vue
@@ -80,9 +80,3 @@ export default {
   }
 }
 </script>
-
-<style scoped>
-  .chart-container {
-    height: 235px;
-  }
-</style>


### PR DESCRIPTION
This PR fixes an issue where a chart's legend would not show up when a chart's adjacent element was a chart that didn't have its legend below.