### PR TITLE
TAO-477 Move to new api v2

### DIFF
--- a/src/components/VerschillenGebied.vue
+++ b/src/components/VerschillenGebied.vue
@@ -217,7 +217,8 @@ export default {
         gwb = this.gebied
       }
       // Return the most actual cijfers to the selected value (own)
-      return util.getGebiedCijfers(this.variable, gwb, util.CIJFERS.LATEST)
+      const result = await util.getGebiedCijfers(this.variable, gwb, util.CIJFERS.LATEST)
+      return { ...result, recent: result.cijfers }
     },
 
     /**

--- a/src/components/charts/DataTable.vue
+++ b/src/components/charts/DataTable.vue
@@ -13,10 +13,10 @@
           <th
             scope="row"
             :rowspan="d.length"
-            v-if="item.meta.tussenkop_kerncijfertabel"
+            v-if="item.meta.tussenkopjeKerncijfertabel"
             valign="top"
           >
-            <span v-if="tussenkop != 'empty'">{{item.meta.tussenkop_kerncijfertabel}}</span>
+            <span v-if="tussenkop != 'empty'">{{item.meta.tussenkopjeKerncijfertabel}}</span>
 
             <span v-else>&nbsp;</span>
           </th>
@@ -76,18 +76,18 @@ export default {
       for (const dataItem of data) {
         const item = Object.assign({}, dataItem)
         const meta = Object.assign({}, dataItem.meta)
-        const tussenKop = (meta && meta.tussenkop_kerncijfertabel) || 'empty'
+        const tussenKop = (meta && meta.tussenkopjeKerncijfertabel) || 'empty'
 
         item.tooltipText = item.tooltip ? item.tooltip(false) : ''
 
         if (tussenKop === 'empty') {
-          meta.tussenkop_kerncijfertabel = 'empty'
+          meta.tussenkopjeKerncijfertabel = 'empty'
         }
 
         if (!Object.keys(categorizedData).includes(tussenKop)) {
           categorizedData[tussenKop] = []
         } else {
-          meta.tussenkop_kerncijfertabel = undefined
+          meta.tussenkopjeKerncijfertabel = undefined
         }
 
         item.meta = meta

--- a/src/services/apis/bbga.js
+++ b/src/services/apis/bbga.js
@@ -106,23 +106,27 @@ async function getCijfers(meta, year = null, gebiedCode = null) {
   const post = meta.symbool === '%' ? meta.symbool : '' // only copy % symbol
 
   const selectVariable = `variabele=${meta.variabele}`
-  const selectYear = year ? `&jaar=${year}` : ''
+  // const selectYear = year ? `&jaar=${year}` : ''
   const selectGebiedCode = gebiedCode ? `&gebiedcode15=${gebiedCode}` : ''
-
+  const isLatest = year === 'latest'
   const url = getUrl(
-    `/cijfers/?${selectVariable}${selectYear}${selectGebiedCode}`
+    `/cijfers/?${selectVariable}${selectGebiedCode}`
   )
   const cijfers = await readPaginatedData(url)
   const std = await getStd()
 
   cijfers.sort((a, b) => a.jaar - b.jaar) // oldest first
-  return cijfers.map(c => ({
+  const results = cijfers.map(c => ({
     jaar: c.jaar,
     waarde: c.waarde === '' || c.waarde === undefined ? null : c.waarde, // Sometimes the API returns '' for null value
     post,
     gebiedcode15: c.gebiedcode15,
     ...getColor(meta, c.waarde, c.jaar, std)
   }))
+
+  console.log('getCijfers cijfers', meta.variabele, year, results)
+
+  return isLatest ? results.pop() : results
 }
 
 /**

--- a/src/services/apis/bbga.js
+++ b/src/services/apis/bbga.js
@@ -28,7 +28,7 @@ function getUrlv1(endpoint) {
  */
 export async function getAllMeta() {
   async function getData() {
-    const url = getUrlv1('/indicatoren_definities/')
+    const url = getUrlv1('/indicatoren_definities/?page_size=1000')
     const data = await readData(url)
     const dataObject = {}
     console.log('getAllMeta data', data)

--- a/src/services/apis/bbga.js
+++ b/src/services/apis/bbga.js
@@ -12,7 +12,6 @@ import { cacheResponse } from '../cache'
  * @returns {string}
  */
 function getUrlv1(endpoint) {
-  console.log('getUrl', endpoint)
   return `https://api.data.amsterdam.nl/v1/bbga${endpoint}`
 }
 

--- a/src/services/apis/bbga.js
+++ b/src/services/apis/bbga.js
@@ -15,6 +15,11 @@ function getUrl(endpoint) {
   return `https://api.data.amsterdam.nl/bbga${endpoint}`
 }
 
+function getUrlv1(endpoint) {
+  console.log('getUrl', endpoint)
+  return `https://api.data.amsterdam.nl/v1/bbga${endpoint}`
+}
+
 /**
  * Get all meta information for the BBGA variables.
  * The data is transformed into an object for faster access
@@ -23,11 +28,12 @@ function getUrl(endpoint) {
  */
 export async function getAllMeta() {
   async function getData() {
-    const url = getUrl('/meta/')
-    const data = await readPaginatedData(url)
+    const url = getUrlv1('/indicatoren_definities/')
+    const data = await readData(url)
     const dataObject = {}
+    console.log('getAllMeta data', data)
 
-    data.forEach(item => {
+    data._embedded.indicatoren_definities.forEach(item => {
       dataObject[item.variabele.toUpperCase()] = item
     })
 

--- a/src/services/apis/bbga.js
+++ b/src/services/apis/bbga.js
@@ -31,7 +31,6 @@ export async function getAllMeta() {
     const url = getUrlv1('/indicatoren_definities/?page_size=1000')
     const data = await readData(url)
     const dataObject = {}
-    console.log('getAllMeta data', data)
 
     data._embedded.indicatoren_definities.forEach(item => {
       dataObject[item.variabele.toUpperCase()] = item

--- a/src/services/apis/bbga.js
+++ b/src/services/apis/bbga.js
@@ -2,7 +2,7 @@
  * All logic regarding the interface with the BBGA API
  */
 
-import { readPaginatedData, readData } from '../datareader'
+import { readData } from '../datareader'
 import { getColor } from '../colorcoding'
 import { cacheResponse } from '../cache'
 
@@ -11,10 +11,6 @@ import { cacheResponse } from '../cache'
  * @param endpoint
  * @returns {string}
  */
-function getUrl(endpoint) {
-  return `https://api.data.amsterdam.nl/bbga${endpoint}`
-}
-
 function getUrlv1(endpoint) {
   console.log('getUrl', endpoint)
   return `https://api.data.amsterdam.nl/v1/bbga${endpoint}`
@@ -105,26 +101,24 @@ export async function getStd() {
 async function getCijfers(meta, year = null, gebiedCode = null) {
   const post = meta.symbool === '%' ? meta.symbool : '' // only copy % symbol
 
-  const selectVariable = `variabele=${meta.variabele}`
-  // const selectYear = year ? `&jaar=${year}` : ''
+  const selectVariable = `indicatorDefinitieId=${meta.variabele}`
   const selectGebiedCode = gebiedCode ? `&gebiedcode15=${gebiedCode}` : ''
   const isLatest = year === 'latest'
-  const url = getUrl(
-    `/cijfers/?${selectVariable}${selectGebiedCode}`
+  const url = getUrlv1(
+    `/kerncijfers/?${selectVariable}${selectGebiedCode}`
   )
-  const cijfers = await readPaginatedData(url)
+  const cijfers = await readData(url)
   const std = await getStd()
 
-  cijfers.sort((a, b) => a.jaar - b.jaar) // oldest first
-  const results = cijfers.map(c => ({
+  const array = cijfers._embedded.kerncijfers
+  array.sort((a, b) => a.jaar - b.jaar) // oldest first
+  const results = array.map(c => ({
     jaar: c.jaar,
     waarde: c.waarde === '' || c.waarde === undefined ? null : c.waarde, // Sometimes the API returns '' for null value
     post,
     gebiedcode15: c.gebiedcode15,
     ...getColor(meta, c.waarde, c.jaar, std)
   }))
-
-  console.log('getCijfers cijfers', meta.variabele, year, results)
 
   return isLatest ? results.pop() : results
 }

--- a/src/services/apis/bbga.js
+++ b/src/services/apis/bbga.js
@@ -104,7 +104,7 @@ async function getCijfers(meta, year = null, gebiedCode = null) {
   const selectGebiedCode = gebiedCode ? `&gebiedcode15=${gebiedCode}` : ''
   const isLatest = year === 'latest'
   const url = getUrlv1(
-    `/kerncijfers/?${selectVariable}${selectGebiedCode}`
+    `/kerncijfers/?${selectVariable}${selectGebiedCode}&page_size=1000`
   )
   const cijfers = await readData(url)
   const std = await getStd()

--- a/src/services/util.js
+++ b/src/services/util.js
@@ -59,7 +59,11 @@ async function getConfigCijfers (gwb, config, recentOrAll = CIJFERS.ALL) {
     try {
       const cijfers = await getGebiedCijfers(c.variabele, gwb, recentOrAll)
       if (c.post) {
-        cijfers.cijfers.forEach(cijfer => { cijfer.post = c.post })
+        if (Array.isArray(cijfers.cijfers)) {
+          cijfers.cijfers.forEach(cijfer => { cijfer.post = c.post })
+        } else {
+          cijfers.cijfers.post = c.post
+        }
       }
       return {
         ...cijfers,


### PR DESCRIPTION
in this PR:
- moved api call form /meta to /indicatoren_definities
- moved api call form /cijfers to /kerncijfers
- variable "variable" is now "indicatorDefinitieId" in api call
- variable "meta.tussenkop_kerncijfertabel" is nog "meta.tussenkopKerncijfertabel"
- fixed recent in VerschillenGebied

[BBGA API new endpoint](https://api.data.amsterdam.nl/v1/bbga/)

Gebied in Beeld site is a vue site for ambtenaren van de gemeente voor alle cijfers in BBGA

[ACC](https://acc.gebiedinbeeld.amsterdam.nl/)
[PROD](https://gebiedinbeeld.amsterdam.nl/)