### PR TITLE
fix: update failing unit-tests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2474,17 +2474,6 @@
             "unique-filename": "^1.1.1"
           }
         },
-        "chalk": {
-          "version": "4.1.2",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "ansi-styles": "^4.1.0",
-            "supports-color": "^7.1.0"
-          }
-        },
         "cliui": {
           "version": "6.0.0",
           "resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
@@ -2519,13 +2508,6 @@
           "requires": {
             "ms": "2.1.2"
           }
-        },
-        "emojis-list": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-3.0.0.tgz",
-          "integrity": "sha512-/kyM18EfinwXZbno9FyUGeFh87KC8HRQBQGildHZbEuRyWFOmv1U10o9BBp8XVZDVNNuQKyIGIu5ZYAAXJ0V2Q==",
-          "dev": true,
-          "optional": true
         },
         "find-cache-dir": {
           "version": "3.3.1",
@@ -2562,28 +2544,6 @@
           "requires": {
             "merge-stream": "^2.0.0",
             "supports-color": "^7.0.0"
-          }
-        },
-        "json5": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.0.tgz",
-          "integrity": "sha512-f+8cldu7X/y7RAJurMEJmdoKXGB/X550w2Nr3tTbezL6RwEE/iMcm+tZnXeoZtKuOq6ft8+CqzEkrIgx1fPoQA==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "minimist": "^1.2.5"
-          }
-        },
-        "loader-utils": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.0.tgz",
-          "integrity": "sha512-rP4F0h2RaWSvPEkD7BLDFQnvSf+nK+wr3ESUjNTyAGobqrijmW92zc+SO6d4p4B1wh7+B/Jg1mkQe5NYUEHtHQ==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "big.js": "^5.2.2",
-            "emojis-list": "^3.0.0",
-            "json5": "^2.1.2"
           }
         },
         "locate-path": {
@@ -2686,18 +2646,6 @@
             "source-map": "^0.6.1",
             "terser": "^4.6.12",
             "webpack-sources": "^1.4.3"
-          }
-        },
-        "vue-loader-v16": {
-          "version": "npm:vue-loader@16.8.1",
-          "resolved": "https://registry.npmjs.org/vue-loader/-/vue-loader-16.8.1.tgz",
-          "integrity": "sha512-V53TJbHmzjBhCG5OYI2JWy/aYDspz4oVHKxS43Iy212GjGIG1T3EsB3+GWXFm/1z5VwjdjLmdZUFYM70y77vtQ==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "chalk": "^4.1.0",
-            "hash-sum": "^2.0.0",
-            "loader-utils": "^2.0.0"
           }
         },
         "wrap-ansi": {
@@ -13259,9 +13207,9 @@
       }
     },
     "regenerator-runtime": {
-      "version": "0.13.7",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz",
-      "integrity": "sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew==",
+      "version": "0.13.9",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.9.tgz",
+      "integrity": "sha512-p3VT+cOEgxFsRRA9X4lkI1E+k2/CtnKtU4gcxyaCUreilL/vqI6CdZ3wxVUx3UOUg+gnUOQQcRI7BmSI656MYA==",
       "dev": true
     },
     "regenerator-transform": {
@@ -16178,6 +16126,111 @@
           "resolved": "https://registry.npmjs.org/hash-sum/-/hash-sum-1.0.2.tgz",
           "integrity": "sha1-M7QHd3VMZDJXPBIMw4CLvRDUfwQ=",
           "dev": true
+        }
+      }
+    },
+    "vue-loader-v16": {
+      "version": "npm:vue-loader@16.8.1",
+      "resolved": "https://registry.npmjs.org/vue-loader/-/vue-loader-16.8.1.tgz",
+      "integrity": "sha512-V53TJbHmzjBhCG5OYI2JWy/aYDspz4oVHKxS43Iy212GjGIG1T3EsB3+GWXFm/1z5VwjdjLmdZUFYM70y77vtQ==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "chalk": "^4.1.0",
+        "hash-sum": "^2.0.0",
+        "loader-utils": "^2.0.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true,
+          "optional": true
+        },
+        "emojis-list": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-3.0.0.tgz",
+          "integrity": "sha512-/kyM18EfinwXZbno9FyUGeFh87KC8HRQBQGildHZbEuRyWFOmv1U10o9BBp8XVZDVNNuQKyIGIu5ZYAAXJ0V2Q==",
+          "dev": true,
+          "optional": true
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true,
+          "optional": true
+        },
+        "json5": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.0.tgz",
+          "integrity": "sha512-f+8cldu7X/y7RAJurMEJmdoKXGB/X550w2Nr3tTbezL6RwEE/iMcm+tZnXeoZtKuOq6ft8+CqzEkrIgx1fPoQA==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "minimist": "^1.2.5"
+          }
+        },
+        "loader-utils": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.0.tgz",
+          "integrity": "sha512-rP4F0h2RaWSvPEkD7BLDFQnvSf+nK+wr3ESUjNTyAGobqrijmW92zc+SO6d4p4B1wh7+B/Jg1mkQe5NYUEHtHQ==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "big.js": "^5.2.2",
+            "emojis-list": "^3.0.0",
+            "json5": "^2.1.2"
+          }
+        },
+        "minimist": {
+          "version": "1.2.5",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+          "dev": true,
+          "optional": true
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "start": "vue-cli-service serve",
     "build": "vue-cli-service build",
     "lint": "vue-cli-service lint",
-    "test:unit": "vue-cli-service test:unit"
+    "test:unit": "vue-cli-service test:unit",
+    "test:unit:watch": "npm run test:unit -- --watch"
   },
   "dependencies": {
     "amsterdam-stijl": "^3.0.5",
@@ -45,6 +46,7 @@
     "eslint-plugin-standard": "^4.1.0",
     "eslint-plugin-vue": "^6.2.2",
     "node-sass": "^4.14.1",
+    "regenerator-runtime": "^0.13.9",
     "vue-template-compiler": "^2.6.12"
   },
   "browserslist": [

--- a/src/services/colorcoding.js
+++ b/src/services/colorcoding.js
@@ -124,7 +124,7 @@ export const CATEGORY_COLORS = [
  * Gets the category from CATEGORY_COLORS for the given z-score
  * @param zScore
  */
-function getCategory (zScore) {
+function getCategory(zScore) {
   const average = 0.5
   const categories = [
     {
@@ -133,15 +133,15 @@ function getCategory (zScore) {
       textColor: CATEGORY_COLORS[0].textColor
     },
     {
-      inCategory: s => (average <= s && s < 2 * average),
+      inCategory: s => average <= s && s < 2 * average,
       color: CATEGORY_COLORS[1].color
     },
     {
-      inCategory: s => (average < s && s < -average),
+      inCategory: s => average < s && s < -average,
       color: CATEGORY_COLORS[2].color
     },
     {
-      inCategory: s => (-average >= s && s > 2 * -average),
+      inCategory: s => -average >= s && s > 2 * -average,
       color: CATEGORY_COLORS[3].color
     },
     {
@@ -163,11 +163,14 @@ function getCategory (zScore) {
  * @param year  The year for which the value is valid
  * @returns {{color, textColor: *|textColor}}
  */
-export function getColor (meta, value, year, stdValue) {
+export function getColor(meta, value, year, stdValue) {
   if (value !== null) {
     const variable = meta.indicatorDefinitieId
     const varStd = stdValue
-      .filter(({ jaar, indicatorDefinitieId }) => indicatorDefinitieId === variable && jaar <= year)
+      .filter(
+        ({ jaar, indicatorDefinitieId }) =>
+          indicatorDefinitieId === variable && jaar <= year
+      )
       .sort((item1, item2) => item2.jaar - item1.jaar)
 
     if (varStd.length) {
@@ -175,7 +178,7 @@ export function getColor (meta, value, year, stdValue) {
       let zScore = (value - ref.gemiddelde) / ref.standaardafwijking
 
       if (meta.kleurenpalet === 2) {
-        zScore = (0 - zScore)
+        zScore = 0 - zScore
       }
 
       const category = getCategory(zScore)
@@ -188,7 +191,9 @@ export function getColor (meta, value, year, stdValue) {
   }
 }
 
-export function getRankingColor (ranking, maxRanking) {
-  const index = Math.round(((ABSOLUTE_COLORS.length - 1) / maxRanking) * ranking)
+export function getRankingColor(ranking, maxRanking) {
+  const index = Math.round(
+    ((ABSOLUTE_COLORS.length - 1) / maxRanking) * ranking
+  )
   return ABSOLUTE_COLORS[index]
 }

--- a/test/unit/setup.js
+++ b/test/unit/setup.js
@@ -6,6 +6,8 @@ import VueAxios from 'vue-axios'
 
 import BootstrapVue from 'bootstrap-vue'
 
+import 'regenerator-runtime/runtime'
+
 Vue.use(Vuex)
 Vue.use(VueAxios, axios)
 Vue.use(BootstrapVue)

--- a/test/unit/specs/bbga.spec.js
+++ b/test/unit/specs/bbga.spec.js
@@ -1,7 +1,7 @@
 import { getAllMeta, getMeta } from '../../../src/services/apis/bbga'
 
 jest.mock('axios', () => ({
-  get: jest.fn((url) => {
+  get: jest.fn(url => {
     const meta = {
       data: {
         _links: {
@@ -9,20 +9,22 @@ jest.mock('axios', () => ({
             href: ''
           }
         },
-        results: [
-          {
-            indicatorDefinitieId: 'x'
-          },
-          {
-            indicatorDefinitieId: 'x2'
-          },
-          {
-            indicatorDefinitieId: 'x1'
-          },
-          {
-            indicatorDefinitieId: 'y'
-          }
-        ]
+        _embedded: {
+          indicatoren_definities: [
+            {
+              variabele: 'x'
+            },
+            {
+              variabele: 'x2'
+            },
+            {
+              variabele: 'x1'
+            },
+            {
+              variabele: 'y'
+            }
+          ]
+        }
       }
     }
     return Promise.resolve(meta)

--- a/test/unit/specs/colorcoding.spec.js
+++ b/test/unit/specs/colorcoding.spec.js
@@ -1,18 +1,18 @@
-import std from '../../../static/tmp/std'
 import { getColor, CATEGORY_COLORS } from '../../../src/services/colorcoding'
 
 describe('colorcoding', () => {
+  const std = []
   std[0] = {
-    'jaar': 2098,
-    'indicatorDefinitieId': 'XYZ',
-    'gem': 123,
-    'SD': 456 // This one should not match
+    jaar: 2098,
+    indicatorDefinitieId: 'XYZ',
+    gemiddelde: 123,
+    standaardafwijking: 456 // This one should not match
   }
   std[1] = {
-    'jaar': 2099,
-    'indicatorDefinitieId': 'XYZ',
-    'gem': 0,
-    'SD': 1 // Make z-score even to value
+    jaar: 2099,
+    indicatorDefinitieId: 'XYZ',
+    gemiddelde: 0,
+    standaardafwijking: 1 // Make z-score even to value
   }
 
   it('should provide the correct category for a color', () => {
@@ -21,11 +21,17 @@ describe('colorcoding', () => {
       kleurenpalet: 9
     }
 
-    expect(getColor(meta, 1, 2099).color).toEqual(CATEGORY_COLORS[0].color)
-    expect(getColor(meta, 0.5, 2099).color).toEqual(CATEGORY_COLORS[1].color)
-    expect(getColor(meta, 0, 2099).color).toEqual(CATEGORY_COLORS[2].color)
-    expect(getColor(meta, -0.5, 2099).color).toEqual(CATEGORY_COLORS[3].color)
-    expect(getColor(meta, -1, 2099).color).toEqual(CATEGORY_COLORS[4].color)
+    expect(getColor(meta, 1, 2099, std).color).toEqual(CATEGORY_COLORS[0].color)
+    expect(getColor(meta, 0.5, 2099, std).color).toEqual(
+      CATEGORY_COLORS[1].color
+    )
+    expect(getColor(meta, 0, 2099, std).color).toEqual(CATEGORY_COLORS[2].color)
+    expect(getColor(meta, -0.5, 2099, std).color).toEqual(
+      CATEGORY_COLORS[3].color
+    )
+    expect(getColor(meta, -1, 2099, std).color).toEqual(
+      CATEGORY_COLORS[4].color
+    )
   })
 
   it('should provide the correct category for a kleurenpalet 2 color', () => {
@@ -34,11 +40,17 @@ describe('colorcoding', () => {
       kleurenpalet: 2
     }
 
-    expect(getColor(meta, -1, 2099).color).toEqual(CATEGORY_COLORS[0].color)
-    expect(getColor(meta, -0.5, 2099).color).toEqual(CATEGORY_COLORS[1].color)
-    expect(getColor(meta, 0, 2099).color).toEqual(CATEGORY_COLORS[2].color)
-    expect(getColor(meta, 0.5, 2099).color).toEqual(CATEGORY_COLORS[3].color)
-    expect(getColor(meta, 1, 2099).color).toEqual(CATEGORY_COLORS[4].color)
+    expect(getColor(meta, -1, 2099, std).color).toEqual(
+      CATEGORY_COLORS[0].color
+    )
+    expect(getColor(meta, -0.5, 2099, std).color).toEqual(
+      CATEGORY_COLORS[1].color
+    )
+    expect(getColor(meta, 0, 2099, std).color).toEqual(CATEGORY_COLORS[2].color)
+    expect(getColor(meta, 0.5, 2099, std).color).toEqual(
+      CATEGORY_COLORS[3].color
+    )
+    expect(getColor(meta, 1, 2099, std).color).toEqual(CATEGORY_COLORS[4].color)
   })
 
   it('should return undefined for an unknown variable', () => {
@@ -47,7 +59,7 @@ describe('colorcoding', () => {
       kleurenpalet: 2
     }
 
-    expect(getColor(meta, 0, 2099)).toEqual(undefined)
+    expect(getColor(meta, 0, 2099, std)).toEqual(undefined)
   })
 
   it('should return undefined for an unkown year', () => {
@@ -56,7 +68,7 @@ describe('colorcoding', () => {
       kleurenpalet: 2
     }
 
-    expect(getColor(meta, 0, 2000)).toEqual(undefined)
+    expect(getColor(meta, 0, 2000, std)).toEqual(undefined)
   })
 
   it('should return undefined for a null value', () => {
@@ -65,6 +77,6 @@ describe('colorcoding', () => {
       kleurenpalet: 9
     }
 
-    expect(getColor(meta, null, 2099)).toEqual(undefined)
+    expect(getColor(meta, null, 2099, std)).toEqual(undefined)
   })
 })

--- a/test/unit/specs/datareader.spec.js
+++ b/test/unit/specs/datareader.spec.js
@@ -1,13 +1,17 @@
 import axios from 'axios'
 
-import { readData, readPaginatedData, HTTPStatus } from '../../../src/services/datareader'
+import {
+  readData,
+  readPaginatedData,
+  HTTPStatus
+} from '../../../src/services/datareader'
 
 const mockData = {
   x: 0
 }
 
 jest.mock('axios', () => ({
-  get: jest.fn((url) => {
+  get: jest.fn(url => {
     const firstData = {
       data: {
         _links: {
@@ -47,7 +51,7 @@ jest.mock('axios', () => ({
   })
 }))
 
-describe('datareader', async () => {
+describe('datareader', () => {
   beforeEach(() => {
     HTTPStatus.error = 0
     HTTPStatus.success = 0
@@ -63,7 +67,7 @@ describe('datareader', async () => {
     } catch (error) {
       expect(data).toEqual(undefined)
     }
-    expect(axios.get).toBeCalledWith('retry')
+    expect(axios.get).toBeCalledWith('retry', {})
     expect(axios.get).toHaveBeenCalledTimes(5)
     expect(global.console.error).toHaveBeenCalledTimes(6)
 
@@ -82,7 +86,7 @@ describe('datareader', async () => {
     } catch (error) {
       expect(data).toEqual(undefined) // should not occur
     }
-    expect(axios.get).toBeCalledWith('retry-n')
+    expect(axios.get).toBeCalledWith('retry-n', {})
     expect(axios.get).toHaveBeenCalledTimes(3)
     expect(data.results).toEqual([1, 2])
 
@@ -93,7 +97,7 @@ describe('datareader', async () => {
 
   it('should read data given an url', async () => {
     const data = await readData('url')
-    expect(axios.get).toBeCalledWith('url')
+    expect(axios.get).toBeCalledWith('url', {})
     expect(data.results).toEqual([1, 2])
 
     expect(HTTPStatus.error).toEqual(0)
@@ -103,8 +107,8 @@ describe('datareader', async () => {
 
   it('should read paginated data given an url', async () => {
     const data = await readPaginatedData('url')
-    expect(axios.get).toBeCalledWith('url?page=1&page_size=1000')
-    expect(axios.get).toBeCalledWith('url?page=2&page_size=1000')
+    expect(axios.get).toBeCalledWith('url?page=1&page_size=1000', {})
+    expect(axios.get).toBeCalledWith('url?page=2&page_size=1000', {})
     expect(data).toEqual([1, 2, 3, 4])
 
     expect(HTTPStatus.error).toEqual(0)


### PR DESCRIPTION
Dit PR corrigeert een aantal bugs waardoor sommige unit-testen niet meer werkten.

- Voegt `regenerator-runtime` toe, dit is een dependency van sommige unit-testen
- Corrigeert de aanroep van `expect(axios.get).toBeCalledWith()` zodat ook de tweede parameter (leeg object) wordt meegenomen in de assertion
- Update de datastructuur van de mock-data in de `bbga` testen zodat deze weer overeenkomt met de API
- Voeg in de `colorcoding` test de `std` als laatste parameter toe in de aanroep van de functie `getColor`