### PR TITLE
Selecteer centrum maar update select niet

### DIFF
--- a/src/components/GWBSelector.tsx
+++ b/src/components/GWBSelector.tsx
@@ -255,8 +255,6 @@ const GWBSelector = () => {
   }, []);
 
   useEffect(() => {
-    updateStadsDeel('A');
-
     // One time only when loading the component update the selection using the query param code (if present)
     function updateSelectionBasedOnQuery() {
       const allAreas = [allData.gebieden, allData.stadsDelen, allData.wijken, allData.buurten].flat();


### PR DESCRIPTION
Op verzoek van de gebruikers wordt het geselecteerde gebied (Centrum) niet geupdate in de selectie. Zo is het makkelijker om na het initieel laden van de site om een ander gebied te selecteren.